### PR TITLE
Added the arm/disarm switch

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -1,66 +1,128 @@
 use core::fmt::Write;
 
-use embedded_graphics::draw_target::DrawTarget;
-use embedded_graphics::mono_font::MonoTextStyleBuilder;
-use embedded_graphics::mono_font::ascii::FONT_10X20;
+use embedded_graphics::mono_font::jis_x0201::FONT_10X20;
+use embedded_graphics::mono_font::{MonoTextStyle, MonoTextStyleBuilder};
 use embedded_graphics::pixelcolor::Rgb565;
 use embedded_graphics::prelude::*;
 use embedded_graphics::text::{Baseline, Text};
 use heapless::String;
 
-/// # Draw Axes
-/// * Define the display style (here just text).
-/// * Store the axes with their name to be displayed.
-/// * Write the data and send it to the LCD screen.
-pub fn draw_axes(
-    display: &mut impl DrawTarget<Color = Rgb565>,
-    throttle: u16,
-    yaw: u16,
-    pitch: u16,
-    roll: u16,
-) {
-    let style = MonoTextStyleBuilder::new()
-        .font(&FONT_10X20)
-        .text_color(Rgb565::WHITE)
-        .background_color(Rgb565::BLACK)
-        .build();
+use crate::init::Lcd;
 
-    // Overwrite "DISARMED" with blanks, then show the 4 axes
-    let mut buf: String<32> = String::new();
-    let _ = write!(buf, "{:<14}", "");
-    let _ = Text::with_baseline(&buf, Point::new(20, 80), style, Baseline::Top).draw(display);
+/// A const function to dynamically create the coords for the 4 axes.
+/// Maybe a bit overkill.
+const fn axes_coords() -> [(i32, i32); 4] {
+    let mut coords = [(0, 0); 4];
+    let mut i = 0;
+    while i < 4 {
+        coords[i] = (20, 20 + (i as i32) * 40);
+        i += 1;
+    }
+    coords
+}
 
-    let axes: [(&str, u16); 4] = [
-        ("Throttle", throttle),
-        ("Yaw", yaw),
-        ("Pitch", pitch),
-        ("Roll", roll),
-    ];
+const DISARMED_COORD: [(i32, i32); 1] = [(20, 80)];
+const AXES_COORD: [(i32, i32); 4] = axes_coords();
 
-    for (i, (label, value)) in axes.iter().enumerate() {
-        let mut buf: String<32> = String::new();
-        let _ = write!(buf, "{:<10}{:>4}", label, value);
-        let y = 20 + (i as i32) * 40;
-        let _ = Text::with_baseline(&buf, Point::new(20, y), style, Baseline::Top).draw(display);
+/// # Page
+/// The currently displayed page (with the text coordinates). For now it can be:
+/// * "DISARMED"
+/// * The 4 axes
+enum Page {
+    Disarmed([(i32, i32); 1]),
+    Axes([(i32, i32); 4]),
+}
+
+impl Page {
+    /// # Coordinates
+    /// Returns the text coordinates of the currently displayed text, in an array.
+    fn coords(&self) -> &[(i32, i32)] {
+        match self {
+            Page::Disarmed(coords) => coords,
+            Page::Axes(coords) => coords,
+        }
     }
 }
 
-/// # Draw "DISARMED"
-/// Overwrite the previous display with blanks, then show DISARMED
-pub fn draw_disarmed(display: &mut impl DrawTarget<Color = Rgb565>) {
-    let style = MonoTextStyleBuilder::new()
-        .font(&FONT_10X20)
-        .text_color(Rgb565::WHITE)
-        .background_color(Rgb565::BLACK)
-        .build();
+/// # Screen
+/// Used to display text on the screen.
+pub struct Screen {
+    /// LCD screen handle
+    pub display: Lcd,
+    /// Currently displayed page
+    page: Page,
+    /// Style to use for the text.
+    style: MonoTextStyle<'static, Rgb565>,
+}
 
-    // Overwrite the 4 axes lines with blanks, then show DISARMED
-    for i in 0..4 {
-        let mut buf: String<32> = String::new();
-        let _ = write!(buf, "{:<14}", "");
-        let y = 20 + (i as i32) * 40;
-        let _ = Text::with_baseline(&buf, Point::new(20, y), style, Baseline::Top).draw(display);
+impl Screen {
+    /// Create a `Screen` instance.
+    pub fn new(display: Lcd) -> Self {
+        let style = MonoTextStyleBuilder::new()
+            .font(&FONT_10X20)
+            .text_color(Rgb565::WHITE)
+            .background_color(Rgb565::BLACK)
+            .build();
+
+        let page = Page::Axes(AXES_COORD);
+
+        Screen {
+            display,
+            page,
+            style,
+        }
     }
 
-    let _ = Text::with_baseline("DISARMED", Point::new(20, 80), style, Baseline::Top).draw(display);
+    /// # Draw Axes
+    /// * Define the display style (here just text).
+    /// * Store the axes with their name to be displayed.
+    /// * Write the data and send it to the LCD screen.
+    pub fn draw_axes(&mut self, throttle: u16, yaw: u16, pitch: u16, roll: u16) {
+        self.erase(); // Overwrite "DISARMED" with blanks, then show the 4 axes
+
+        // Write the axes into the screen
+        let axes: [(&str, u16); 4] = [
+            ("Throttle", throttle),
+            ("Yaw", yaw),
+            ("Pitch", pitch),
+            ("Roll", roll),
+        ];
+
+        for (i, (label, value)) in axes.iter().enumerate() {
+            let mut buf: String<32> = String::new();
+            let _ = write!(buf, "{:<10}{:>4}", label, value);
+            let y = 20 + (i as i32) * 40;
+            let _ = Text::with_baseline(&buf, Point::new(20, y), self.style, Baseline::Top)
+                .draw(&mut self.display);
+        }
+
+        self.page = Page::Axes(AXES_COORD); // New current page is the 4 axes
+    }
+
+    /// # Draw "DISARMED"
+    /// Overwrite the previous display with blanks, then show DISARMED
+    pub fn draw_disarmed(&mut self) {
+        self.erase(); // Overwrite the 4 axes lines with blanks, then show DISARMED
+
+        // Write "DISARMED" on the screen
+        let _ = Text::with_baseline("DISARMED", Point::new(20, 80), self.style, Baseline::Top)
+            .draw(&mut self.display);
+
+        self.page = Page::Disarmed(DISARMED_COORD); // New current page is "DISARMED"
+    }
+
+    /// # Erase Current Page
+    /// Get the display coordinates of the current page and for each coordinates:
+    /// * Create an empty String buffer
+    /// * Write the empty buffer into the screen
+    ///
+    /// This overwrites the previous text at these coordinates.
+    fn erase(&mut self) {
+        for &(x, y) in self.page.coords() {
+            let mut buf: String<32> = String::new();
+            let _ = write!(buf, "{:<14}", "");
+            let _ = Text::with_baseline(&buf, Point::new(x, y), self.style, Baseline::Top)
+                .draw(&mut self.display);
+        }
+    }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -25,6 +25,11 @@ pub fn draw_axes(
         .background_color(Rgb565::BLACK)
         .build();
 
+    // Overwrite "DISARMED" with blanks, then show the 4 axes
+    let mut buf: String<32> = String::new();
+    let _ = write!(buf, "{:<14}", "");
+    let _ = Text::with_baseline(&buf, Point::new(20, 80), style, Baseline::Top).draw(display);
+
     let axes: [(&str, u16); 4] = [
         ("Throttle", throttle),
         ("Yaw", yaw),
@@ -38,4 +43,24 @@ pub fn draw_axes(
         let y = 20 + (i as i32) * 40;
         let _ = Text::with_baseline(&buf, Point::new(20, y), style, Baseline::Top).draw(display);
     }
+}
+
+/// # Draw "DISARMED"
+/// Overwrite the previous display with blanks, then show DISARMED
+pub fn draw_disarmed(display: &mut impl DrawTarget<Color = Rgb565>) {
+    let style = MonoTextStyleBuilder::new()
+        .font(&FONT_10X20)
+        .text_color(Rgb565::WHITE)
+        .background_color(Rgb565::BLACK)
+        .build();
+
+    // Overwrite the 4 axes lines with blanks, then show DISARMED
+    for i in 0..4 {
+        let mut buf: String<32> = String::new();
+        let _ = write!(buf, "{:<14}", "");
+        let y = 20 + (i as i32) * 40;
+        let _ = Text::with_baseline(&buf, Point::new(20, y), style, Baseline::Top).draw(display);
+    }
+
+    let _ = Text::with_baseline("DISARMED", Point::new(20, 80), style, Baseline::Top).draw(display);
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,6 +1,6 @@
 use embassy_executor::Spawner;
 use embassy_stm32::adc::{Adc, SampleTime};
-use embassy_stm32::gpio::{Level, Output, Speed};
+use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
 use embassy_stm32::mode::Blocking;
 use embassy_stm32::peripherals::{ADC1, PA0, PA1, PB0, PB1, USB_OTG_FS};
 use embassy_stm32::spi::{self, Spi};
@@ -62,6 +62,7 @@ pub fn init_rc(
     PB1,
     CdcAcmClass<'static, Driver<'static, USB_OTG_FS>>,
     Lcd,
+    Input<'static>,
 ) {
     // Configure clocks: HSE 25 MHz (typical BlackPill) -> PLL -> 84 MHz sys, 48 MHz USB
     let mut config = Config::default();
@@ -158,5 +159,8 @@ pub fn init_rc(
     let usb_device = builder.build();
     spawner.must_spawn(usb_task(usb_device));
 
-    (adc, p.PA0, p.PA1, p.PB0, p.PB1, cdc, display)
+    // ARM/DISARM switch
+    let arm_switch = Input::new(p.PA5, Pull::Up);
+
+    (adc, p.PA0, p.PA1, p.PB0, p.PB1, cdc, display, arm_switch)
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -18,6 +18,8 @@ use embedded_hal_bus::spi::ExclusiveDevice;
 use mipidsi::models::ILI9341Rgb565;
 use mipidsi::options::{Orientation, Rotation};
 
+use crate::display::Screen;
+
 bind_interrupts!(struct Irqs {
     OTG_FS => embassy_stm32::usb::InterruptHandler<peripherals::USB_OTG_FS>;
 });
@@ -61,7 +63,7 @@ pub fn init_rc(
     PB0,
     PB1,
     CdcAcmClass<'static, Driver<'static, USB_OTG_FS>>,
-    Lcd,
+    Screen,
     Input<'static>,
 ) {
     // Configure clocks: HSE 25 MHz (typical BlackPill) -> PLL -> 84 MHz sys, 48 MHz USB
@@ -111,6 +113,7 @@ pub fn init_rc(
         .unwrap();
 
     display.clear(Rgb565::BLACK).unwrap();
+    let screen = Screen::new(display);
 
     // ADC setup
     let mut adc = Adc::new(p.ADC1);
@@ -162,5 +165,5 @@ pub fn init_rc(
     // ARM/DISARM switch
     let arm_switch = Input::new(p.PA5, Pull::Up);
 
-    (adc, p.PA0, p.PA1, p.PB0, p.PB1, cdc, display, arm_switch)
+    (adc, p.PA0, p.PA1, p.PB0, p.PB1, cdc, screen, arm_switch)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ use panic_rtt_target as _;
 use rtt_target::rtt_init_print;
 
 use read_gpio::axis::Axis;
-use read_gpio::display::{draw_axes, draw_disarmed};
 use read_gpio::init::init_rc;
 
 const INTERVAL_US: u64 = 1000;
@@ -29,7 +28,7 @@ async fn main(spawner: Spawner) {
         mut pin_pitch,
         mut pin_roll,
         mut cdc,
-        mut display,
+        mut screen,
         arm_switch,
     ) = init_rc(spawner);
 
@@ -55,9 +54,9 @@ async fn main(spawner: Spawner) {
         if display_counter >= DISPLAY_INTERVAL {
             display_counter = 0;
             if arm_switch.is_low() {
-                draw_axes(&mut display, throttle, yaw, pitch, roll);
+                screen.draw_axes(throttle, yaw, pitch, roll);
             } else {
-                draw_disarmed(&mut display);
+                screen.draw_disarmed();
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use panic_rtt_target as _;
 use rtt_target::rtt_init_print;
 
 use read_gpio::axis::Axis;
-use read_gpio::display::draw_axes;
+use read_gpio::display::{draw_axes, draw_disarmed};
 use read_gpio::init::init_rc;
 
 const INTERVAL_US: u64 = 1000;
@@ -22,8 +22,16 @@ async fn main(spawner: Spawner) {
     // RTT is only used for logs over ST-LINK/SWD.
     rtt_init_print!();
 
-    let (mut adc, mut pin_throttle, mut pin_yaw, mut pin_pitch, mut pin_roll, mut cdc, mut display) =
-        init_rc(spawner);
+    let (
+        mut adc,
+        mut pin_throttle,
+        mut pin_yaw,
+        mut pin_pitch,
+        mut pin_roll,
+        mut cdc,
+        mut display,
+        arm_switch,
+    ) = init_rc(spawner);
 
     let mut throttle_axis = Axis::new();
     let mut yaw_axis = Axis::new();
@@ -46,7 +54,11 @@ async fn main(spawner: Spawner) {
         display_counter += 1;
         if display_counter >= DISPLAY_INTERVAL {
             display_counter = 0;
-            draw_axes(&mut display, throttle, yaw, pitch, roll);
+            if arm_switch.is_low() {
+                draw_axes(&mut display, throttle, yaw, pitch, roll);
+            } else {
+                draw_disarmed(&mut display);
+            }
         }
 
         let mut buf: String<64> = String::new();


### PR DESCRIPTION
This closes issue #10.

Now, there is an arm/disarm switch wired to GND and A5. The screen displays either "DISARMED" or the 4 axes values. The system always send the axes data via serial.

I need to make a test bench before merging into `dev`.